### PR TITLE
doc: Java 6 compat note

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ It provides caching and signature verification.
 </plugin>
 ```
 
+## Java compatibility
+
+If you use Java 6, you should use `maven-download-plugin@1.2.1`. Newer versions are not compatible with Java 6.
+
 ## Help
 
 ### Maven help


### PR DESCRIPTION
Version 1.3.0 of the plugin doesn't work with Java 6

Sadly some of us are stuck with Java 6 on ancient corporate build infrastructures :)